### PR TITLE
 Fix: Avoid mutable default arguments in Index and AppendableIndex classes

### DIFF
--- a/minsearch.py
+++ b/minsearch.py
@@ -27,7 +27,7 @@ class Index:
         docs (list): List of documents indexed.
     """
 
-    def __init__(self, text_fields, keyword_fields, vectorizer_params={}):
+    def __init__(self, text_fields, keyword_fields, vectorizer_params=None):
         """
         Initializes the Index with specified text and keyword fields.
 
@@ -38,6 +38,8 @@ class Index:
         """
         self.text_fields = text_fields
         self.keyword_fields = keyword_fields
+        if vectorizer_params is None:
+            vectorizer_params = {}
 
         self.vectorizers = {
             field: TfidfVectorizer(**vectorizer_params) for field in text_fields
@@ -68,7 +70,7 @@ class Index:
 
         return self
 
-    def search(self, query, filter_dict={}, boost_dict={}, num_results=10):
+    def search(self, query, filter_dict=None, boost_dict=None, num_results=10):
         """
         Searches the index with the given query, filters, and boost parameters.
 
@@ -81,6 +83,11 @@ class Index:
         Returns:
             list of dict: List of documents matching the search criteria, ranked by relevance.
         """
+        if filter_dict is None:
+            filter_dict = {}
+        if boost_dict is None:
+            boost_dict = {}
+
         query_vecs = {
             field: self.vectorizers[field].transform([query])
             for field in self.text_fields

--- a/minsearch/append.py
+++ b/minsearch/append.py
@@ -445,7 +445,7 @@ class AppendableIndex:
         return self
 
     def search(
-        self, query, filter_dict={}, boost_dict={}, num_results=10, output_ids=False
+        self, query, filter_dict=None, boost_dict=None, num_results=10, output_ids=False
     ):
         """
         Searches the index with the given query, filters, and boost parameters.
@@ -461,6 +461,11 @@ class AppendableIndex:
             list of dict: List of documents matching the search criteria, ranked by relevance.
                          If output_ids is True, each document will have an additional '_id' field.
         """
+        if filter_dict is None:
+            filter_dict = {}
+        if boost_dict is None:
+            boost_dict = {}
+            
         if not self.docs:
             return []
 

--- a/minsearch/minsearch.py
+++ b/minsearch/minsearch.py
@@ -19,7 +19,7 @@ class Index:
         docs (list): List of documents indexed.
     """
 
-    def __init__(self, text_fields, keyword_fields, vectorizer_params={}):
+    def __init__(self, text_fields, keyword_fields, vectorizer_params=None):
         """
         Initializes the Index with specified text and keyword fields.
 
@@ -30,6 +30,8 @@ class Index:
         """
         self.text_fields = text_fields
         self.keyword_fields = keyword_fields
+        if vectorizer_params is None:
+            vectorizer_params = {}
 
         # Set default vectorizer parameters to ensure we always have terms
         default_params = {
@@ -81,7 +83,7 @@ class Index:
 
         return self
 
-    def search(self, query, filter_dict={}, boost_dict={}, num_results=10, output_ids=False):
+    def search(self, query, filter_dict=None, boost_dict=None, num_results=10, output_ids=False):
         """
         Searches the index with the given query, filters, and boost parameters.
 
@@ -96,6 +98,11 @@ class Index:
             list of dict: List of documents matching the search criteria, ranked by relevance.
                          If output_ids is True, each document will have an additional '_id' field.
         """
+        if filter_dict is None:
+            filter_dict = {}
+        if boost_dict is None:
+            boost_dict = {}
+            
         if not self.docs:
             return []
             


### PR DESCRIPTION
This PR fixes the use of mutable default arguments in the `search()` and `__init__()` methods of the `Index` class and the `search()` method in the `AppendableIndex` class.  Mutable defaults like `boost_dict={}` and `filter_dict={}` are shared across function calls, which can lead to unexpected behavior if these dictionaries are ever mutated. This change replaces them with `None` and initializes them safely within the method body.

**Simple test to prove that this is not a Python best practice:**
```python
def foo(arg={}):
    print(arg)
    arg["called"] = True
    print(arg, '\n')

foo()
foo()
```

**Output:**
```bash
{}
{'called': True}

{'called': True} # Mutation persisted!  
{'called': True}  
```